### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/copy-asset-in-memory-webpack-plugin/security/code-scanning/1](https://github.com/sibiraj-s/copy-asset-in-memory-webpack-plugin/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a test workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made near the top of the file, after the `name` and before `on` or `env` keys.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
